### PR TITLE
auth: role conflict fix and remembered account selector

### DIFF
--- a/app/context/AuthContext.tsx
+++ b/app/context/AuthContext.tsx
@@ -13,15 +13,31 @@ interface StartYandexAuthInput {
   role: AuthRole;
 }
 
+interface RememberedAccount {
+  id: string;
+  userId: string;
+  email: string;
+  displayName: string;
+  avatarUrl: string | null;
+  role: AuthRole | null;
+  accessToken: string;
+  refreshToken: string;
+  lastUsedAt: string;
+}
+
 interface AuthContextType {
   status: AuthStatus;
   session: Session | null;
   user: User | null;
   isCompletingOAuth: boolean;
   oauthError: string | null;
+  rememberedAccounts: RememberedAccount[];
   startYandexAuth: (input: StartYandexAuthInput) => Promise<ActionResult<void>>;
+  switchRememberedAccount: (accountId: string) => Promise<ActionResult<{ role: AuthRole | null }>>;
+  forgetRememberedAccount: (accountId: string) => void;
   clearOAuthError: () => void;
   signOut: () => Promise<ActionResult<void>>;
+  signOutAll: () => Promise<ActionResult<void>>;
 }
 
 interface PendingYandexRegistration {
@@ -30,12 +46,16 @@ interface PendingYandexRegistration {
   createdAt: string;
 }
 
+type UserMetadata = Record<string, unknown>;
+
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 const DEFAULT_APP_URL = 'https://pvz-schedule.vercel.app';
 const DEFAULT_YANDEX_PROVIDER = 'custom:yandex';
 const DEFAULT_YANDEX_SCOPES = 'login:email login:info';
 const PENDING_YANDEX_STORAGE_KEY = 'pvz-schedule.pending-yandex-registration';
+const REMEMBERED_ACCOUNTS_STORAGE_KEY = 'pvz-schedule.remembered-accounts';
+const MAX_REMEMBERED_ACCOUNTS = 5;
 
 const getAppUrl = (): string => {
   const configuredAppUrl = import.meta.env.VITE_APP_URL?.trim();
@@ -44,12 +64,7 @@ const getAppUrl = (): string => {
     return configuredAppUrl.replace(/\/+$/, '');
   }
 
-  if (typeof window === 'undefined') {
-    return DEFAULT_APP_URL;
-  }
-
-  const hostname = window.location.hostname.toLowerCase();
-  if (hostname === 'localhost' || hostname === '127.0.0.1') {
+  if (typeof window !== 'undefined') {
     return window.location.origin;
   }
 
@@ -122,6 +137,88 @@ const clearPendingYandexRegistration = () => {
   window.localStorage.removeItem(PENDING_YANDEX_STORAGE_KEY);
 };
 
+const isRememberedAccount = (value: unknown): value is RememberedAccount => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  const validRole = record.role === null || record.role === 'admin' || record.role === 'employee';
+
+  return typeof record.id === 'string'
+    && typeof record.userId === 'string'
+    && typeof record.email === 'string'
+    && typeof record.displayName === 'string'
+    && (record.avatarUrl === null || typeof record.avatarUrl === 'string')
+    && validRole
+    && typeof record.accessToken === 'string'
+    && typeof record.refreshToken === 'string'
+    && typeof record.lastUsedAt === 'string';
+};
+
+const normalizeRememberedAccounts = (accounts: RememberedAccount[]): RememberedAccount[] => {
+  const deduped = new Map<string, RememberedAccount>();
+
+  for (const account of accounts) {
+    const existing = deduped.get(account.userId);
+    if (!existing) {
+      deduped.set(account.userId, account);
+      continue;
+    }
+
+    deduped.set(account.userId, {
+      ...existing,
+      ...account,
+      role: account.role ?? existing.role ?? null,
+      displayName: account.displayName || existing.displayName,
+      avatarUrl: account.avatarUrl ?? existing.avatarUrl,
+      lastUsedAt: account.lastUsedAt >= existing.lastUsedAt ? account.lastUsedAt : existing.lastUsedAt,
+    });
+  }
+
+  return Array.from(deduped.values())
+    .sort((left, right) => right.lastUsedAt.localeCompare(left.lastUsedAt))
+    .slice(0, MAX_REMEMBERED_ACCOUNTS);
+};
+
+const readRememberedAccounts = (): RememberedAccount[] => {
+  if (typeof window === 'undefined') {
+    return [];
+  }
+
+  const raw = window.localStorage.getItem(REMEMBERED_ACCOUNTS_STORAGE_KEY);
+  if (!raw) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    return normalizeRememberedAccounts(parsed.filter(isRememberedAccount));
+  } catch {
+    return [];
+  }
+};
+
+const writeRememberedAccounts = (accounts: RememberedAccount[]) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (accounts.length === 0) {
+    window.localStorage.removeItem(REMEMBERED_ACCOUNTS_STORAGE_KEY);
+    return;
+  }
+
+  window.localStorage.setItem(
+    REMEMBERED_ACCOUNTS_STORAGE_KEY,
+    JSON.stringify(normalizeRememberedAccounts(accounts)),
+  );
+};
+
 const readAuthErrorFromLocation = (): string | null => {
   if (typeof window === 'undefined') {
     return null;
@@ -143,12 +240,100 @@ const readAuthErrorFromLocation = (): string | null => {
   return translateSupabaseError(decodeURIComponent(rawMessage.replace(/\+/g, ' ')));
 };
 
+const getUserMetadata = (session: Session): UserMetadata => (
+  session.user.user_metadata && typeof session.user.user_metadata === 'object'
+    ? session.user.user_metadata as UserMetadata
+    : {}
+);
+
+const firstNonEmptyString = (...values: unknown[]): string => {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return '';
+};
+
+const buildRememberedAccount = (
+  session: Session,
+  role: AuthRole | null,
+  fallbackDisplayName = '',
+): RememberedAccount => {
+  const userMetadata = getUserMetadata(session);
+  const displayName = firstNonEmptyString(
+    fallbackDisplayName,
+    userMetadata.full_name,
+    userMetadata.name,
+    userMetadata.display_name,
+    session.user.email?.split('@')[0],
+    session.user.email,
+  ) || 'Аккаунт';
+
+  const avatarUrl = firstNonEmptyString(
+    userMetadata.avatar_url,
+    userMetadata.picture,
+    userMetadata.image,
+  ) || null;
+
+  return {
+    id: session.user.id,
+    userId: session.user.id,
+    email: session.user.email ?? '',
+    displayName,
+    avatarUrl,
+    role,
+    accessToken: session.access_token,
+    refreshToken: session.refresh_token,
+    lastUsedAt: new Date().toISOString(),
+  };
+};
+
+const upsertRememberedAccount = (
+  accounts: RememberedAccount[],
+  nextAccount: RememberedAccount,
+): RememberedAccount[] => {
+  const existing = accounts.find((account) => account.userId === nextAccount.userId);
+
+  const merged: RememberedAccount = existing
+    ? {
+        ...existing,
+        ...nextAccount,
+        role: nextAccount.role ?? existing.role ?? null,
+        displayName: nextAccount.displayName || existing.displayName,
+        avatarUrl: nextAccount.avatarUrl ?? existing.avatarUrl,
+        email: nextAccount.email || existing.email,
+      }
+    : nextAccount;
+
+  return normalizeRememberedAccounts([
+    merged,
+    ...accounts.filter((account) => account.userId !== nextAccount.userId),
+  ]);
+};
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [status, setStatus] = useState<AuthStatus>(isSupabaseConfigured ? 'loading' : 'missing-config');
   const [isCompletingOAuth, setIsCompletingOAuth] = useState(false);
   const [oauthError, setOAuthError] = useState<string | null>(null);
+  const [rememberedAccounts, setRememberedAccounts] = useState<RememberedAccount[]>(() => readRememberedAccounts());
   const sessionUserId = session?.user?.id ?? null;
+
+  const rememberSession = useCallback((
+    nextSession: Session,
+    role: AuthRole | null,
+    fallbackDisplayName = '',
+  ) => {
+    setRememberedAccounts((prev) => (
+      upsertRememberedAccount(prev, buildRememberedAccount(nextSession, role, fallbackDisplayName))
+    ));
+  }, []);
+
+  useEffect(() => {
+    writeRememberedAccounts(rememberedAccounts);
+  }, [rememberedAccounts]);
 
   useEffect(() => {
     if (!supabase) {
@@ -171,11 +356,41 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       setSession(data.session);
       setStatus(data.session ? 'authenticated' : 'unauthenticated');
+
+      if (data.session) {
+        setRememberedAccounts((prev) => {
+          const existing = prev.find((account) => account.userId === data.session!.user.id);
+          return upsertRememberedAccount(
+            prev,
+            buildRememberedAccount(
+              data.session,
+              existing?.role ?? null,
+              existing?.displayName ?? '',
+            ),
+          );
+        });
+      }
     })();
 
     const { data } = supabase.auth.onAuthStateChange((_event, nextSession) => {
       setSession(nextSession);
       setStatus(nextSession ? 'authenticated' : 'unauthenticated');
+
+      if (!nextSession) {
+        return;
+      }
+
+      setRememberedAccounts((prev) => {
+        const existing = prev.find((account) => account.userId === nextSession.user.id);
+        return upsertRememberedAccount(
+          prev,
+          buildRememberedAccount(
+            nextSession,
+            existing?.role ?? null,
+            existing?.displayName ?? '',
+          ),
+        );
+      });
     });
 
     return () => {
@@ -192,7 +407,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [sessionUserId]);
 
   useEffect(() => {
-    if (!sessionUserId) {
+    if (!sessionUserId || !session) {
       setIsCompletingOAuth(false);
       return;
     }
@@ -225,6 +440,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         return;
       }
 
+      rememberSession(session, result.data.role, pendingRegistration.displayName);
       setOAuthError(null);
       setIsCompletingOAuth(false);
     })();
@@ -232,7 +448,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       isActive = false;
     };
-  }, [sessionUserId]);
+  }, [rememberSession, session, sessionUserId]);
 
   const startYandexAuth = useCallback(async (input: StartYandexAuthInput): Promise<ActionResult<void>> => {
     const clientResult = ensureSupabaseClient();
@@ -257,6 +473,43 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return okResult(undefined, 'Открываю вход через Яндекс ID...');
   }, []);
 
+  const switchRememberedAccount = useCallback(async (accountId: string): Promise<ActionResult<{ role: AuthRole | null }>> => {
+    const clientResult = ensureSupabaseClient();
+    if (!clientResult.ok) return clientResult;
+
+    const account = rememberedAccounts.find((item) => item.id === accountId || item.userId === accountId);
+    if (!account) {
+      return errorResult('Этот аккаунт не найден в списке.');
+    }
+
+    clearPendingYandexRegistration();
+    setOAuthError(null);
+
+    const { data, error } = await clientResult.data.auth.setSession({
+      access_token: account.accessToken,
+      refresh_token: account.refreshToken,
+    });
+
+    if (error) {
+      return errorResult(translateSupabaseError(error.message));
+    }
+
+    if (data.session) {
+      rememberSession(data.session, account.role, account.displayName);
+    }
+
+    return okResult(
+      { role: account.role ?? null },
+      account.displayName ? `Переключаю на ${account.displayName}.` : 'Переключаю аккаунт.',
+    );
+  }, [rememberSession, rememberedAccounts]);
+
+  const forgetRememberedAccount = useCallback((accountId: string) => {
+    setRememberedAccounts((prev) => (
+      prev.filter((account) => account.id !== accountId && account.userId !== accountId)
+    ));
+  }, []);
+
   const clearOAuthError = useCallback(() => {
     setOAuthError(null);
   }, []);
@@ -271,8 +524,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const { error } = await clientResult.data.auth.signOut();
     if (error) return errorResult(translateSupabaseError(error.message));
 
-    return okResult(undefined, 'Ты вышел из аккаунта.');
+    return okResult(undefined, 'Ты вышел из текущего аккаунта.');
   }, []);
+
+  const signOutAll = useCallback(async (): Promise<ActionResult<void>> => {
+    const signOutResult = await signOut();
+    if (!signOutResult.ok) {
+      return signOutResult;
+    }
+
+    setRememberedAccounts([]);
+    return okResult(undefined, 'Все сохранённые аккаунты удалены.');
+  }, [signOut]);
 
   const value = useMemo<AuthContextType>(() => ({
     status,
@@ -280,10 +543,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     user: session?.user ?? null,
     isCompletingOAuth,
     oauthError,
+    rememberedAccounts,
     startYandexAuth,
+    switchRememberedAccount,
+    forgetRememberedAccount,
     clearOAuthError,
     signOut,
-  }), [clearOAuthError, isCompletingOAuth, oauthError, session, signOut, startYandexAuth, status]);
+    signOutAll,
+  }), [
+    clearOAuthError,
+    forgetRememberedAccount,
+    isCompletingOAuth,
+    oauthError,
+    rememberedAccounts,
+    session,
+    signOut,
+    signOutAll,
+    startYandexAuth,
+    status,
+    switchRememberedAccount,
+  ]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/app/lib/supabaseErrors.ts
+++ b/app/lib/supabaseErrors.ts
@@ -12,6 +12,8 @@
   { pattern: /INVALID_ROLE/i, message: 'Указана неверная роль.' },
   { pattern: /EMAIL_NOT_CONFIRMED/i, message: 'Подтверди email через провайдера входа.' },
   { pattern: /REGISTRATION_NOT_FOUND|REGISTRATION_REQUIRED/i, message: 'Для этого аккаунта не найдена регистрация. Выбери роль и войди ещё раз.' },
+  { pattern: /ACCOUNT_ROLE_CONFLICT_ADMIN/i, message: 'Этот email уже привязан к администратору. Войди как администратор или используй другой аккаунт.' },
+  { pattern: /ACCOUNT_ROLE_CONFLICT_EMPLOYEE/i, message: 'Этот email уже привязан к сотруднику. Войди как сотрудник или используй другой аккаунт.' },
   { pattern: /ADMIN_ALREADY_EXISTS/i, message: 'Администратор уже зарегистрирован. Войди под его аккаунтом.' },
   { pattern: /ADMIN_REQUIRED/i, message: 'Сначала должен зарегистрироваться администратор.' },
   { pattern: /PROFILE_REQUIRED/i, message: 'Профиль ещё не готов. Попробуй войти ещё раз.' },

--- a/app/pages/Auth.tsx
+++ b/app/pages/Auth.tsx
@@ -1,4 +1,4 @@
-﻿import { Database, LogIn, Shield, UserRoundPlus } from 'lucide-react';
+﻿import { ArrowRightLeft, Database, LogIn, LogOut, Plus, Shield, Trash2, UserCircle2, UserRoundPlus } from 'lucide-react';
 import { useMemo, useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
@@ -23,8 +23,8 @@ const FEATURE_CARDS = [
   },
   {
     icon: UserRoundPlus,
-    title: 'Вход через Яндекс ID',
-    body: 'Без magic link и почтовой возни: входишь через Яндекс, а роль подтягивается автоматически.',
+    title: 'Переключение аккаунтов',
+    body: 'Повторно авторизовываться не нужно: знакомые аккаунты можно открывать прямо с экрана входа.',
   },
 ] as const;
 
@@ -32,11 +32,28 @@ const getLandingPath = (role: 'admin' | 'employee') => (
   role === 'admin' ? '/admin/dashboard' : '/employee/dashboard'
 );
 
+const getRoleLabel = (role: 'admin' | 'employee' | null) => {
+  if (role === 'admin') return 'Администратор';
+  if (role === 'employee') return 'Сотрудник';
+  return 'Без роли';
+};
+
+const getInitials = (value: string) => {
+  const chunks = value.trim().split(/\s+/).filter(Boolean);
+  if (chunks.length === 0) return '•';
+  return chunks.slice(0, 2).map((item) => item[0]?.toUpperCase() ?? '').join('') || '•';
+};
+
 export default function AuthPage() {
   const navigate = useNavigate();
   const { access, status: appStatus, error: appError } = useApp();
   const {
     startYandexAuth,
+    switchRememberedAccount,
+    forgetRememberedAccount,
+    signOut,
+    signOutAll,
+    rememberedAccounts,
     status,
     user,
     isCompletingOAuth,
@@ -47,8 +64,11 @@ export default function AuthPage() {
   const [displayName, setDisplayName] = useState('');
   const [role, setRole] = useState<'admin' | 'employee'>('employee');
   const [submitting, setSubmitting] = useState(false);
+  const [switchingAccountId, setSwitchingAccountId] = useState<string | null>(null);
+  const [signOutMode, setSignOutMode] = useState<'current' | 'all' | null>(null);
 
-  const isBusy = status === 'loading' || status === 'missing-config' || isCompletingOAuth || submitting;
+  const currentUserId = user?.id ?? null;
+  const isBusy = status === 'loading' || status === 'missing-config' || isCompletingOAuth || submitting || !!switchingAccountId || signOutMode !== null;
   const currentError = oauthError ?? (status === 'authenticated' && !access ? appError : null);
   const landingPath = access ? getLandingPath(access.role) : null;
 
@@ -58,11 +78,15 @@ export default function AuthPage() {
     }
 
     if (status === 'authenticated' && access) {
-      return 'Аккаунт уже готов. Можно сразу открыть приложение.';
+      return 'Аккаунт уже готов. Можно открыть кабинет или быстро переключиться на другой сохранённый аккаунт.';
     }
 
-    return 'Используй тот же Яндекс-аккаунт, к которому привязан твой рабочий email. Если ты уже был зарегистрирован, роль восстановится сама.';
-  }, [access, status]);
+    if (rememberedAccounts.length > 0) {
+      return 'Ниже есть сохранённые аккаунты. Их можно открыть сразу, без повторной авторизации через провайдера.';
+    }
+
+    return 'Используй тот же Яндекс-аккаунт, к которому привязан твой рабочий email. Для нового аккаунта выбери роль ниже и войди один раз.';
+  }, [access, rememberedAccounts.length, status]);
 
   const handleYandexAuth = async () => {
     setSubmitting(true);
@@ -83,6 +107,58 @@ export default function AuthPage() {
     toast.success(result.message ?? 'Открываю вход через Яндекс ID...');
   };
 
+  const handleSwitchRememberedAccount = async (accountId: string, accountRole: 'admin' | 'employee' | null) => {
+    setSwitchingAccountId(accountId);
+    clearOAuthError();
+
+    const result = await switchRememberedAccount(accountId);
+
+    setSwitchingAccountId(null);
+
+    if (!result.ok) {
+      toast.error(result.error);
+      return;
+    }
+
+    toast.success(result.message ?? 'Аккаунт переключён.');
+
+    const nextRole = result.data.role ?? accountRole;
+    if (nextRole) {
+      navigate(getLandingPath(nextRole), { replace: true });
+    }
+  };
+
+  const handleForgetRememberedAccount = (accountId: string, label: string) => {
+    forgetRememberedAccount(accountId);
+    toast.success(`Аккаунт ${label} удалён из локального списка.`);
+  };
+
+  const handleSignOutCurrent = async () => {
+    setSignOutMode('current');
+    const result = await signOut();
+    setSignOutMode(null);
+
+    if (!result.ok) {
+      toast.error(result.error);
+      return;
+    }
+
+    toast.success(result.message ?? 'Текущий аккаунт закрыт.');
+  };
+
+  const handleSignOutAll = async () => {
+    setSignOutMode('all');
+    const result = await signOutAll();
+    setSignOutMode(null);
+
+    if (!result.ok) {
+      toast.error(result.error);
+      return;
+    }
+
+    toast.success(result.message ?? 'Все аккаунты очищены.');
+  };
+
   return (
     <main className="min-h-screen bg-[radial-gradient(circle_at_top,#fff7ed,white_38%,#f5f5f4)] px-4 py-6 sm:px-6 lg:px-10">
       <div className="mx-auto grid min-h-[calc(100vh-3rem)] max-w-6xl gap-6 lg:grid-cols-[1.2fr_0.95fr]">
@@ -98,8 +174,7 @@ export default function AuthPage() {
                   Вход и регистрация через Яндекс ID
                 </h1>
                 <p className="max-w-xl text-base leading-7 text-stone-600">
-                  Мы убрали нестабильный вход по письмам. Теперь новый пользователь выбирает роль,
-                  заходит через Яндекс, а система сама создаёт или восстанавливает профиль по email.
+                  Здесь можно как первый раз войти через Яндекс, так и быстро открыть уже знакомый аккаунт — почти как в сервисах Google или Яндекса, только без лишней бюрократии.
                 </p>
               </div>
             </div>
@@ -133,10 +208,100 @@ export default function AuthPage() {
                 <p className="text-sm text-emerald-900">
                   Ты уже вошёл{user?.email ? ` как ${user.email}` : ''}. Доступ {access.role === 'admin' ? 'администратора' : 'сотрудника'} активен.
                 </p>
-                <Button onClick={() => navigate(landingPath, { replace: true })} className="w-full bg-emerald-600 hover:bg-emerald-500">
-                  Открыть приложение
-                </Button>
+                <div className="flex flex-wrap gap-2">
+                  <Button onClick={() => navigate(landingPath, { replace: true })} className="bg-emerald-600 hover:bg-emerald-500">
+                    Открыть приложение
+                  </Button>
+                  <Button variant="outline" onClick={() => void handleSignOutCurrent()} disabled={signOutMode !== null}>
+                    <LogOut className="h-4 w-4" />
+                    {signOutMode === 'current' ? 'Выход...' : 'Выйти из текущего'}
+                  </Button>
+                </div>
               </div>
+            ) : null}
+
+            {rememberedAccounts.length > 0 ? (
+              <section className="space-y-4">
+                <SectionTitle
+                  title="Сохранённые аккаунты"
+                  subtitle="Можно открыть уже знакомый аккаунт без повторной авторизации через провайдера."
+                />
+
+                <div className="grid gap-3">
+                  {rememberedAccounts.map((account) => {
+                    const isCurrent = currentUserId === account.userId && status === 'authenticated';
+
+                    return (
+                      <div key={account.id} className="rounded-2xl border border-stone-200 bg-white p-4 shadow-sm">
+                        <div className="flex items-start gap-3">
+                          {account.avatarUrl ? (
+                            <img
+                              src={account.avatarUrl}
+                              alt={account.displayName}
+                              className="h-11 w-11 rounded-full object-cover"
+                            />
+                          ) : (
+                            <div className="flex h-11 w-11 items-center justify-center rounded-full bg-stone-100 text-sm font-semibold text-stone-700">
+                              {getInitials(account.displayName || account.email)}
+                            </div>
+                          )}
+
+                          <div className="min-w-0 flex-1 space-y-1">
+                            <div className="flex flex-wrap items-center gap-2">
+                              <div className="truncate text-sm font-semibold text-stone-900">
+                                {account.displayName || account.email}
+                              </div>
+                              <span className="rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-700">
+                                {getRoleLabel(account.role)}
+                              </span>
+                              {isCurrent ? (
+                                <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+                                  Текущий
+                                </span>
+                              ) : null}
+                            </div>
+                            <div className="truncate text-xs text-stone-500">{account.email}</div>
+                          </div>
+                        </div>
+
+                        <div className="mt-4 flex flex-wrap gap-2">
+                          {isCurrent && landingPath ? (
+                            <Button variant="outline" onClick={() => navigate(landingPath, { replace: true })}>
+                              <UserCircle2 className="h-4 w-4" />
+                              Открыть
+                            </Button>
+                          ) : (
+                            <Button
+                              variant="outline"
+                              onClick={() => void handleSwitchRememberedAccount(account.id, account.role)}
+                              disabled={isBusy}
+                            >
+                              <ArrowRightLeft className="h-4 w-4" />
+                              {switchingAccountId === account.id ? 'Переключаю...' : 'Войти'}
+                            </Button>
+                          )}
+
+                          <Button
+                            variant="outline"
+                            onClick={() => handleForgetRememberedAccount(account.id, account.displayName || account.email)}
+                            disabled={isBusy}
+                          >
+                            <Trash2 className="h-4 w-4" />
+                            Забыть
+                          </Button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+
+                <div className="flex flex-wrap gap-2">
+                  <Button variant="outline" onClick={() => void handleSignOutAll()} disabled={signOutMode !== null}>
+                    <Trash2 className="h-4 w-4" />
+                    {signOutMode === 'all' ? 'Очищаю...' : 'Забыть все аккаунты'}
+                  </Button>
+                </div>
+              </section>
             ) : null}
 
             {status === 'authenticated' && !access ? (
@@ -149,8 +314,10 @@ export default function AuthPage() {
 
             <section className="space-y-4">
               <SectionTitle
-                title="Продолжить через Яндекс"
-                subtitle="Для нового пользователя роль выбирается перед входом. Для уже зарегистрированного роль и имя ниже можно не менять."
+                title={rememberedAccounts.length > 0 ? 'Добавить ещё аккаунт' : 'Продолжить через Яндекс'}
+                subtitle={rememberedAccounts.length > 0
+                  ? 'Новый аккаунт тоже попадёт в локальный список и потом будет открываться в один тап.'
+                  : 'Для нового пользователя роль выбирается перед входом. Для уже зарегистрированного роль и имя ниже можно не менять.'}
               />
 
               <Field label="Как тебя показывать в системе (необязательно)">
@@ -198,14 +365,14 @@ export default function AuthPage() {
                 onClick={() => void handleYandexAuth()}
                 disabled={isBusy}
               >
-                <LogIn className="h-4 w-4" />
-                {submitting ? 'Перенаправляю...' : 'Войти через Яндекс ID'}
+                {rememberedAccounts.length > 0 ? <Plus className="h-4 w-4" /> : <LogIn className="h-4 w-4" />}
+                {submitting ? 'Перенаправляю...' : rememberedAccounts.length > 0 ? 'Добавить аккаунт через Яндекс ID' : 'Войти через Яндекс ID'}
               </Button>
             </section>
 
             <div className="rounded-2xl border border-stone-200 bg-stone-50 p-4 text-sm leading-6 text-stone-600">
               Если сотрудник уже создан администратором, входи через тот же Яндекс-аккаунт, где указан этот email.
-              Система сама привяжет профиль к сотруднику.
+              Система сама привяжет профиль к сотруднику и запомнит его для следующего входа.
             </div>
 
             {status === 'missing-config' ? (

--- a/supabase/migrations/20260409210000_auth_role_conflict_fix.sql
+++ b/supabase/migrations/20260409210000_auth_role_conflict_fix.sql
@@ -1,0 +1,392 @@
+begin;
+
+create or replace function public.ensure_profile_from_auth(
+  desired_role_input text default null,
+  display_name_input text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  current_user_id uuid := auth.uid();
+  current_user_email text;
+  existing_profile public.profiles;
+  email_matched_profile public.profiles;
+  request_row public.registration_requests;
+  request_found boolean := false;
+  admin_profile public.profiles;
+  target_org public.organizations;
+  target_employee public.employees;
+  resolved_role text;
+  requested_role text;
+  fallback_name text;
+  linked_employee_role text;
+begin
+  if current_user_id is null then
+    raise exception 'AUTH_REQUIRED';
+  end if;
+
+  select lower(nullif(trim(au.email), ''))
+  into current_user_email
+  from auth.users au
+  where au.id = current_user_id;
+
+  if current_user_email is null then
+    raise exception 'EMAIL_REQUIRED';
+  end if;
+
+  select p.* into existing_profile
+  from public.profiles p
+  where p.id = current_user_id;
+
+  if found and existing_profile.is_active then
+    return jsonb_build_object(
+      'organization_id', existing_profile.organization_id,
+      'role', existing_profile.role
+    );
+  end if;
+
+  select rr.* into request_row
+  from public.registration_requests rr
+  where rr.email = current_user_email
+  limit 1
+  for update;
+
+  request_found := found;
+
+  requested_role := lower(trim(coalesce(
+    nullif(desired_role_input, ''),
+    case when request_found then request_row.desired_role else null end,
+    ''
+  )));
+
+  if requested_role = '' then
+    requested_role := null;
+  end if;
+
+  if requested_role is not null and requested_role not in ('admin', 'employee') then
+    raise exception 'INVALID_ROLE';
+  end if;
+
+  select p.* into email_matched_profile
+  from public.profiles p
+  join auth.users au on au.id = p.id
+  where lower(coalesce(au.email, '')) = current_user_email
+    and p.id <> current_user_id
+  order by
+    case when p.is_active then 0 else 1 end,
+    case when p.role = 'admin' then 0 else 1 end,
+    p.created_at asc
+  limit 1
+  for update of p;
+
+  if found then
+    if requested_role is not null and requested_role <> email_matched_profile.role then
+      if email_matched_profile.role = 'admin' then
+        raise exception 'ACCOUNT_ROLE_CONFLICT_ADMIN';
+      else
+        raise exception 'ACCOUNT_ROLE_CONFLICT_EMPLOYEE';
+      end if;
+    end if;
+
+    resolved_role := email_matched_profile.role;
+    fallback_name := coalesce(
+      nullif(trim(display_name_input), ''),
+      nullif(trim(email_matched_profile.display_name), ''),
+      nullif(split_part(current_user_email, '@', 1), ''),
+      case when resolved_role = 'admin' then 'Администратор' else 'Сотрудник' end
+    );
+
+    if resolved_role = 'admin' then
+      update public.organizations
+      set created_by = current_user_id,
+          updated_at = now()
+      where id = email_matched_profile.organization_id
+        and coalesce(created_by, email_matched_profile.id) = email_matched_profile.id;
+    end if;
+
+    update public.profiles
+    set is_active = false,
+        updated_at = now()
+    where id = email_matched_profile.id
+      and id <> current_user_id;
+
+    insert into public.profiles (id, organization_id, role, display_name, is_active)
+    values (current_user_id, email_matched_profile.organization_id, resolved_role, fallback_name, true)
+    on conflict (id) do update
+    set organization_id = excluded.organization_id,
+        role = excluded.role,
+        display_name = excluded.display_name,
+        is_active = true,
+        updated_at = now();
+
+    perform public.sync_profile_membership(current_user_id);
+
+    if request_found then
+      update public.registration_requests
+      set consumed_at = now(),
+          consumed_by = current_user_id
+      where email = request_row.email;
+    end if;
+
+    select p.* into existing_profile
+    from public.profiles p
+    where p.id = current_user_id;
+
+    perform public.append_audit_log(
+      existing_profile.organization_id,
+      current_user_id,
+      'profile',
+      current_user_id,
+      'oauth_identity_linked',
+      jsonb_build_object('legacy_profile_id', email_matched_profile.id),
+      jsonb_build_object('role', existing_profile.role, 'email', current_user_email)
+    );
+
+    return jsonb_build_object(
+      'organization_id', existing_profile.organization_id,
+      'role', existing_profile.role
+    );
+  end if;
+
+  select e.* into target_employee
+  from public.employees e
+  where lower(coalesce(e.work_email, '')) = current_user_email
+    and e.archived = false
+  order by
+    case when e.is_owner then 0 else 1 end,
+    case when e.status = 'active' then 0 else 1 end,
+    e.created_at asc
+  limit 1
+  for update;
+
+  if found then
+    select o.* into target_org
+    from public.organizations o
+    where o.id = target_employee.organization_id;
+
+    select p.role into linked_employee_role
+    from public.profiles p
+    where p.id = target_employee.profile_id;
+
+    select p.* into admin_profile
+    from public.profiles p
+    where p.organization_id = target_employee.organization_id
+      and p.role = 'admin'
+      and p.is_active = true
+    order by p.created_at asc
+    limit 1;
+
+    resolved_role := case
+      when target_employee.is_owner then 'admin'
+      when linked_employee_role = 'admin' then 'admin'
+      else 'employee'
+    end;
+
+    if requested_role is not null and requested_role <> resolved_role then
+      if resolved_role = 'admin' then
+        raise exception 'ACCOUNT_ROLE_CONFLICT_ADMIN';
+      else
+        raise exception 'ACCOUNT_ROLE_CONFLICT_EMPLOYEE';
+      end if;
+    end if;
+
+    if resolved_role = 'admin'
+      and admin_profile.id is not null
+      and admin_profile.id <> current_user_id
+      and admin_profile.id <> target_employee.profile_id then
+      raise exception 'ADMIN_ALREADY_EXISTS';
+    end if;
+
+    fallback_name := coalesce(
+      nullif(trim(display_name_input), ''),
+      nullif(trim(target_employee.name), ''),
+      nullif(split_part(current_user_email, '@', 1), ''),
+      case when resolved_role = 'admin' then 'Администратор' else 'Сотрудник' end
+    );
+
+    if target_employee.profile_id is not null and target_employee.profile_id <> current_user_id then
+      update public.profiles
+      set is_active = false,
+          updated_at = now()
+      where id = target_employee.profile_id;
+    end if;
+
+    insert into public.profiles (id, organization_id, role, display_name, is_active)
+    values (current_user_id, target_org.id, resolved_role, fallback_name, true)
+    on conflict (id) do update
+    set organization_id = excluded.organization_id,
+        role = excluded.role,
+        display_name = excluded.display_name,
+        is_active = true,
+        updated_at = now();
+
+    if resolved_role = 'admin' then
+      update public.organizations
+      set created_by = current_user_id,
+          updated_at = now()
+      where id = target_org.id;
+    end if;
+
+    update public.employees
+    set user_id = case
+          when resolved_role = 'admin' then current_user_id
+          else coalesce(user_id, public.owner_user_id_for_org(target_org.id), current_user_id)
+        end,
+        profile_id = current_user_id,
+        auth_user_id = current_user_id,
+        work_email = current_user_email,
+        status = 'active',
+        archived = false,
+        archived_at = null,
+        is_owner = (resolved_role = 'admin'),
+        hired_at = coalesce(hired_at, current_date),
+        terminated_at = null,
+        name = coalesce(nullif(trim(name), ''), fallback_name),
+        created_by_profile_id = coalesce(created_by_profile_id, admin_profile.id, current_user_id),
+        updated_at = now()
+    where id = target_employee.id
+    returning * into target_employee;
+
+    perform public.sync_profile_membership(current_user_id);
+
+    if request_found then
+      update public.registration_requests
+      set consumed_at = now(),
+          consumed_by = current_user_id
+      where email = request_row.email;
+    end if;
+
+    select p.* into existing_profile
+    from public.profiles p
+    where p.id = current_user_id;
+
+    perform public.append_audit_log(
+      existing_profile.organization_id,
+      current_user_id,
+      'profile',
+      current_user_id,
+      'oauth_employee_linked',
+      jsonb_build_object('employee_id', target_employee.id),
+      jsonb_build_object('role', existing_profile.role, 'email', current_user_email)
+    );
+
+    return jsonb_build_object(
+      'organization_id', existing_profile.organization_id,
+      'role', existing_profile.role
+    );
+  end if;
+
+  resolved_role := requested_role;
+
+  if resolved_role not in ('admin', 'employee') then
+    raise exception 'REGISTRATION_REQUIRED';
+  end if;
+
+  fallback_name := coalesce(
+    nullif(trim(display_name_input), ''),
+    nullif(trim(case when request_found then request_row.display_name else null end), ''),
+    nullif(split_part(current_user_email, '@', 1), ''),
+    case when resolved_role = 'admin' then 'Администратор' else 'Сотрудник' end
+  );
+
+  if resolved_role = 'admin' then
+    select p.* into admin_profile
+    from public.profiles p
+    where p.role = 'admin'
+      and p.is_active = true
+      and p.id <> current_user_id
+    order by p.created_at asc
+    limit 1;
+
+    if found then
+      raise exception 'ADMIN_ALREADY_EXISTS';
+    end if;
+
+    select o.* into target_org
+    from public.organizations o
+    where o.created_by = current_user_id
+    order by o.created_at asc
+    limit 1;
+
+    if not found then
+      insert into public.organizations (name, created_by)
+      values ('PVZ Schedule', current_user_id)
+      returning * into target_org;
+    end if;
+
+    insert into public.profiles (id, organization_id, role, display_name, is_active)
+    values (current_user_id, target_org.id, 'admin', fallback_name, true)
+    on conflict (id) do update
+    set organization_id = excluded.organization_id,
+        role = 'admin',
+        display_name = excluded.display_name,
+        is_active = true,
+        updated_at = now();
+
+    update public.organizations
+    set created_by = current_user_id,
+        updated_at = now()
+    where id = target_org.id;
+  else
+    select p.* into admin_profile
+    from public.profiles p
+    where p.role = 'admin'
+      and p.is_active = true
+    order by p.created_at asc
+    limit 1;
+
+    if not found then
+      raise exception 'ADMIN_REQUIRED';
+    end if;
+
+    select o.* into target_org
+    from public.organizations o
+    where o.id = admin_profile.organization_id
+    limit 1;
+
+    insert into public.profiles (id, organization_id, role, display_name, is_active)
+    values (current_user_id, target_org.id, 'employee', fallback_name, true)
+    on conflict (id) do update
+    set organization_id = excluded.organization_id,
+        role = 'employee',
+        display_name = excluded.display_name,
+        is_active = true,
+        updated_at = now();
+  end if;
+
+  perform public.sync_profile_membership(current_user_id);
+
+  if request_found then
+    update public.registration_requests
+    set consumed_at = now(),
+        consumed_by = current_user_id
+    where email = request_row.email;
+  end if;
+
+  select p.* into existing_profile
+  from public.profiles p
+  where p.id = current_user_id;
+
+  perform public.append_audit_log(
+    existing_profile.organization_id,
+    current_user_id,
+    'profile',
+    current_user_id,
+    'oauth_registration_completed',
+    null,
+    jsonb_build_object('role', existing_profile.role, 'email', current_user_email)
+  );
+
+  return jsonb_build_object(
+    'organization_id', existing_profile.organization_id,
+    'role', existing_profile.role
+  );
+end;
+$$;
+
+grant execute on function public.ensure_profile_from_auth(text, text) to authenticated;
+
+commit;


### PR DESCRIPTION
- stop silent oauth role override
- show explicit role conflict errors
- remember local accounts after successful login
- allow switching remembered accounts from the auth screen without repeating provider auth
- add forget current/all account actions
