### PR TITLE
[codex] Redesign payments as compact journal

### DIFF
--- a/app/components/AddPaymentModal.tsx
+++ b/app/components/AddPaymentModal.tsx
@@ -88,11 +88,11 @@ export function AddPaymentModal({
     <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{t('Добавить выплату', 'Add payment')}</DialogTitle>
+          <DialogTitle>{t('Добавить выплату сотруднику', 'Add employee payment')}</DialogTitle>
           <DialogDescription>
             {t(
-              'Сотрудник создаёт запрос на выплату, а администратор потом подтверждает его.',
-              'An employee creates a payment request and the administrator confirms it later.',
+              'Зафиксируй дату, сумму и комментарий. Запись сохранится в журнале выплат.',
+              'Record the date, amount, and comment. The entry will be saved to the payment journal.',
             )}
           </DialogDescription>
         </DialogHeader>
@@ -161,7 +161,7 @@ export function AddPaymentModal({
             {t('Отмена', 'Cancel')}
           </Button>
           <Button onClick={() => void handleSubmit()} disabled={!canSubmit}>
-            {submitting ? t('Сохраняю...', 'Saving...') : t('Сохранить выплату', 'Save payment')}
+            {submitting ? t('Сохраняю...', 'Saving...') : t('Зафиксировать выплату', 'Record payment')}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/app/components/EditPaymentModal.tsx
+++ b/app/components/EditPaymentModal.tsx
@@ -80,8 +80,8 @@ export function EditPaymentModal({
           <DialogTitle>{t('Изменить выплату', 'Edit payment')}</DialogTitle>
           <DialogDescription>
             {t(
-              'Можно поправить сумму, дату и комментарий до финального подтверждения.',
-              'You can edit the amount, date, and comment before final approval.',
+              'Можно поправить сумму, дату и комментарий записи в журнале.',
+              'You can edit the amount, date, and comment for this journal entry.',
             )}
           </DialogDescription>
         </DialogHeader>

--- a/app/components/PaymentStatusBadge.tsx
+++ b/app/components/PaymentStatusBadge.tsx
@@ -11,15 +11,15 @@ export function PaymentStatusBadge({ status }: PaymentStatusBadgeProps) {
 
   const statusMeta: Record<PaymentStatus, { label: string; className: string }> = {
     pending: {
-      label: t('На подтверждении', 'Pending'),
+      label: t('Ожидает', 'Pending'),
       className: 'border-amber-200 bg-amber-50 text-amber-700',
     },
     approved: {
-      label: t('Подтверждена', 'Approved'),
+      label: t('Учтена', 'Counted'),
       className: 'border-emerald-200 bg-emerald-50 text-emerald-700',
     },
     rejected: {
-      label: t('Отклонена', 'Rejected'),
+      label: t('Не учитывается', 'Not counted'),
       className: 'border-rose-200 bg-rose-50 text-rose-700',
     },
   };

--- a/app/pages/Payments.tsx
+++ b/app/pages/Payments.tsx
@@ -1,4 +1,4 @@
-﻿import { CheckCircle2, Pencil, Trash2, Wallet, XCircle } from 'lucide-react';
+import { Pencil, Trash2, Wallet } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { AddPaymentModal } from '../components/AddPaymentModal';
@@ -16,6 +16,7 @@ import {
 } from '../components/ui/table';
 import { useApp } from '../context/AppContext';
 import { useLanguage } from '../context/LanguageContext';
+import type { Payment } from '../domain/types';
 
 const money = (value: number, locale: string) => new Intl.NumberFormat(locale, {
   style: 'currency',
@@ -23,11 +24,81 @@ const money = (value: number, locale: string) => new Intl.NumberFormat(locale, {
   maximumFractionDigits: 0,
 }).format(value);
 
+const paymentSortValue = (payment: Payment): string => (
+  `${payment.date}T${payment.createdAt ?? ''}`
+);
+
+const sortPaymentsDesc = (payments: Payment[]): Payment[] => (
+  [...payments].sort((left, right) => paymentSortValue(right).localeCompare(paymentSortValue(left)))
+);
+
+const getMonthKey = (date: string): string => date.slice(0, 7);
+
+const formatMonthLabel = (monthKey: string, locale: string): string => {
+  const [year, month] = monthKey.split('-').map(Number);
+  const date = new Date(year, month - 1, 1);
+  const label = new Intl.DateTimeFormat(locale, {
+    month: 'long',
+    year: 'numeric',
+  }).format(date);
+
+  return label.charAt(0).toUpperCase() + label.slice(1);
+};
+
+interface PaymentMonthGroup {
+  key: string;
+  label: string;
+  payments: Payment[];
+  approvedTotal: number;
+  legacyCount: number;
+}
+
+const groupPaymentsByMonth = (payments: Payment[], locale: string): PaymentMonthGroup[] => {
+  const byMonth = new Map<string, Payment[]>();
+
+  sortPaymentsDesc(payments).forEach((payment) => {
+    const key = getMonthKey(payment.date);
+    const monthPayments = byMonth.get(key) ?? [];
+    monthPayments.push(payment);
+    byMonth.set(key, monthPayments);
+  });
+
+  return [...byMonth.entries()]
+    .sort(([left], [right]) => right.localeCompare(left))
+    .map(([key, monthPayments]) => ({
+      key,
+      label: formatMonthLabel(key, locale),
+      payments: monthPayments,
+      approvedTotal: monthPayments
+        .filter((payment) => payment.status === 'approved')
+        .reduce((sum, payment) => sum + payment.amount, 0),
+      legacyCount: monthPayments.filter((payment) => payment.status !== 'approved').length,
+    }));
+};
+
 interface EditPaymentState {
   paymentId: string;
   amount: number;
   date: string;
   comment: string;
+}
+
+interface SummaryItemProps {
+  label: string;
+  value: string;
+}
+
+function SummaryItem({ label, value }: SummaryItemProps) {
+  return (
+    <div className="rounded-lg border bg-white px-3 py-2 shadow-sm">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-0.5 text-sm font-semibold text-stone-900">
+        {value}
+      </div>
+    </div>
+  );
 }
 
 export default function PaymentsPage() {
@@ -38,8 +109,6 @@ export default function PaymentsPage() {
     addPayment,
     updatePayment,
     deletePayment,
-    confirmPayment,
-    rejectPayment,
     isOwner,
     myEmployeeId,
   } = useApp();
@@ -54,6 +123,10 @@ export default function PaymentsPage() {
     return active.filter((employee) => employee.id === myEmployeeId);
   }, [employees, isOwner, myEmployeeId]);
 
+  const employeeById = useMemo(() => (
+    new Map(employees.map((employee) => [employee.id, employee]))
+  ), [employees]);
+
   const visiblePayments = useMemo(() => {
     const scoped = isOwner
       ? payments
@@ -63,19 +136,18 @@ export default function PaymentsPage() {
     return scoped.filter((payment) => payment.employeeId === selectedEmployeeId);
   }, [isOwner, myEmployeeId, payments, selectedEmployeeId]);
 
-  const pendingCount = useMemo(() => (
-    visiblePayments.filter((payment) => payment.status === 'pending').length
-  ), [visiblePayments]);
-
-  const approvedCount = useMemo(() => (
-    visiblePayments.filter((payment) => payment.status === 'approved').length
-  ), [visiblePayments]);
+  const paymentGroups = useMemo(
+    () => groupPaymentsByMonth(visiblePayments, locale),
+    [locale, visiblePayments],
+  );
 
   const totalApproved = useMemo(() => (
     visiblePayments
       .filter((payment) => payment.status === 'approved')
       .reduce((sum, payment) => sum + payment.amount, 0)
   ), [visiblePayments]);
+
+  const latestMonth = paymentGroups[0] ?? null;
 
   const handleAddPayment = async (input: Parameters<typeof addPayment>[0]) => {
     const result = await addPayment(input);
@@ -90,8 +162,8 @@ export default function PaymentsPage() {
 
   const handleDeletePayment = async (id: string) => {
     const confirmed = window.confirm(t(
-      'Удалить выплату? Это действие нельзя отменить.',
-      'Delete this payment? This action cannot be undone.',
+      'Удалить запись выплаты? Это действие нельзя отменить.',
+      'Delete this payment record? This action cannot be undone.',
     ));
     if (!confirmed) return;
 
@@ -102,26 +174,6 @@ export default function PaymentsPage() {
     }
 
     toast.success(t('Выплата удалена.', 'Payment deleted.'));
-  };
-
-  const handleConfirmPayment = async (id: string) => {
-    const result = await confirmPayment(id);
-    if (!result.ok) {
-      toast.error(result.error);
-      return;
-    }
-
-    toast.success(t('Выплата подтверждена.', 'Payment approved.'));
-  };
-
-  const handleRejectPayment = async (id: string) => {
-    const result = await rejectPayment(id);
-    if (!result.ok) {
-      toast.error(result.error);
-      return;
-    }
-
-    toast.success(t('Выплата отклонена.', 'Payment rejected.'));
   };
 
   const handleEditPayment = async (payload: EditPaymentState) => {
@@ -141,169 +193,222 @@ export default function PaymentsPage() {
   };
 
   return (
-    <div className="bg-stone-50">
-      <main className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-5 sm:px-6">
-        <Card>
-          <CardContent className="flex flex-col gap-3 p-5 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex flex-wrap items-center gap-2">
-              <div className="rounded-full bg-stone-100 px-3 py-1 text-xs font-semibold text-stone-700">
-                {isOwner ? t('Все выплаты ПВЗ', 'All PVZ payments') : t('Твои выплаты', 'Your payments')}
+    <div className="min-h-screen bg-stone-50">
+      <main
+        className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-5 sm:px-6"
+        data-testid="payments-journal"
+      >
+        <Card data-testid="payments-summary">
+          <CardContent className="p-4 sm:p-5">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+              <div>
+                <div className="text-xs font-semibold uppercase tracking-wide text-stone-500">
+                  {isOwner ? t('Журнал выплат ПВЗ', 'PVZ payment journal') : t('История выплат', 'Payment history')}
+                </div>
+                <h1 className="mt-1 text-2xl font-semibold tracking-tight text-stone-950">
+                  {isOwner ? t('Выплаты сотрудникам', 'Employee payments') : t('Мои выплаты', 'My payments')}
+                </h1>
+                <p className="mt-1 hidden max-w-2xl text-sm text-muted-foreground sm:block">
+                  {t(
+                    'Компактная история фактических выплат без лишних действий и больших карточек.',
+                    'A compact history of recorded payments without extra actions or large cards.',
+                  )}
+                </p>
               </div>
-              <div className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
-                {t('На подтверждении', 'Pending')}: {pendingCount}
+
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                {isOwner ? (
+                  <select
+                    className="h-9 rounded-md border bg-input-background px-3 text-sm"
+                    value={selectedEmployeeId}
+                    onChange={(event) => setSelectedEmployeeId(event.target.value)}
+                    aria-label={t('Фильтр по сотруднику', 'Employee filter')}
+                  >
+                    <option value="all">{t('Все сотрудники', 'All employees')}</option>
+                    {visibleEmployees.map((employee) => (
+                      <option key={employee.id} value={employee.id}>
+                        {employee.name}
+                      </option>
+                    ))}
+                  </select>
+                ) : null}
+
+                {isOwner ? (
+                  <Button
+                    className="h-9"
+                    onClick={() => setModalOpen(true)}
+                    data-testid="add-payment-button"
+                  >
+                    <Wallet className="h-4 w-4" />
+                    {t('Зафиксировать выплату', 'Record payment')}
+                  </Button>
+                ) : null}
               </div>
             </div>
 
-            <Button onClick={() => setModalOpen(true)}>
-              <Wallet className="h-4 w-4" />
-              {t('Добавить выплату', 'Add payment')}
-            </Button>
+            <div className="mt-4 flex flex-wrap gap-2">
+              <SummaryItem
+                label={t('Записей', 'Records')}
+                value={String(visiblePayments.length)}
+              />
+              <SummaryItem
+                label={t('Учтено в расчете', 'Counted in payroll')}
+                value={money(totalApproved, locale)}
+              />
+              <SummaryItem
+                label={t('Свежий месяц', 'Latest month')}
+                value={latestMonth
+                  ? `${latestMonth.label}: ${money(latestMonth.approvedTotal, locale)}`
+                  : t('Нет записей', 'No records')}
+              />
+            </div>
           </CardContent>
         </Card>
 
-        <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {paymentGroups.length > 0 ? (
+          <section className="flex flex-col gap-4">
+            {paymentGroups.map((group) => (
+              <Card
+                key={group.key}
+                className="gap-0 overflow-hidden"
+                data-testid="payment-month-group"
+                data-month-key={group.key}
+              >
+                <CardHeader className="flex flex-col gap-2 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-5">
+                  <div>
+                    <CardTitle className="text-base font-semibold text-stone-950">
+                      {group.label}
+                    </CardTitle>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {t('Записей', 'Records')}: {group.payments.length}
+                      {' · '}
+                      {t('Учтено в расчете', 'Counted in payroll')}: {money(group.approvedTotal, locale)}
+                    </div>
+                  </div>
+                  {group.legacyCount > 0 ? (
+                    <div className="rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800">
+                      {t('Особые записи', 'Special records')}: {group.legacyCount}
+                    </div>
+                  ) : null}
+                </CardHeader>
+
+                <CardContent className="overflow-x-auto p-0">
+                  <Table className="min-w-[760px] table-fixed">
+                    <TableHeader>
+                      <TableRow className="bg-stone-50/70">
+                        <TableHead className="w-[112px] px-4 py-2 text-xs">{t('Дата', 'Date')}</TableHead>
+                        <TableHead className="w-[220px] px-4 py-2 text-xs">{t('Сотрудник', 'Employee')}</TableHead>
+                        <TableHead className="w-[140px] px-4 py-2 text-xs">{t('Сумма', 'Amount')}</TableHead>
+                        <TableHead className="px-4 py-2 text-xs">{t('Комментарий', 'Comment')}</TableHead>
+                        {isOwner ? (
+                          <TableHead className="w-[132px] px-4 py-2 text-right text-xs">
+                            {t('Действия', 'Actions')}
+                          </TableHead>
+                        ) : null}
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {group.payments.map((payment) => {
+                        const employee = employeeById.get(payment.employeeId);
+                        const canEdit = isOwner;
+                        const canDelete = isOwner && payment.status !== 'approved';
+                        const comment = payment.comment.trim() || t('Без комментария', 'No comment');
+
+                        return (
+                          <TableRow key={payment.id} data-testid="payment-row">
+                            <TableCell className="px-4 py-2 text-sm font-medium text-stone-800">
+                              {payment.date}
+                            </TableCell>
+                            <TableCell className="px-4 py-2 text-sm">
+                              <div className="font-medium text-stone-900">
+                                {employee?.name ?? t('Сотрудник', 'Employee')}
+                              </div>
+                            </TableCell>
+                            <TableCell className="px-4 py-2 text-sm font-semibold text-stone-950">
+                              {money(payment.amount, locale)}
+                            </TableCell>
+                            <TableCell className="px-4 py-2 text-sm">
+                              <div className="flex min-w-0 max-w-[360px] items-center gap-2">
+                                <span className="truncate text-stone-700" title={comment}>
+                                  {comment}
+                                </span>
+                                {payment.status !== 'approved' ? (
+                                  <span data-testid="payment-legacy-status">
+                                    <PaymentStatusBadge status={payment.status} />
+                                  </span>
+                                ) : null}
+                              </div>
+                            </TableCell>
+                            {isOwner ? (
+                              <TableCell className="px-4 py-2 text-right" data-testid="payment-actions">
+                                <div className="flex justify-end gap-1">
+                                  {canEdit ? (
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      className="h-8 px-2"
+                                      onClick={() => setEditingPayment({
+                                        paymentId: payment.id,
+                                        amount: payment.amount,
+                                        date: payment.date,
+                                        comment: payment.comment,
+                                      })}
+                                    >
+                                      <Pencil className="h-3.5 w-3.5" />
+                                      <span className="sr-only sm:not-sr-only sm:ml-1">{t('Изменить', 'Edit')}</span>
+                                    </Button>
+                                  ) : null}
+                                  {canDelete ? (
+                                    <Button
+                                      variant="outline"
+                                      size="sm"
+                                      className="h-8 px-2 text-rose-700 hover:text-rose-800"
+                                      onClick={() => void handleDeletePayment(payment.id)}
+                                    >
+                                      <Trash2 className="h-3.5 w-3.5" />
+                                      <span className="sr-only sm:not-sr-only sm:ml-1">{t('Удалить', 'Delete')}</span>
+                                    </Button>
+                                  ) : null}
+                                </div>
+                              </TableCell>
+                            ) : null}
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                </CardContent>
+              </Card>
+            ))}
+          </section>
+        ) : (
           <Card>
-            <CardContent className="p-4">
-              <div className="text-xs text-muted-foreground">{t('Всего записей', 'Total records')}</div>
-              <div className="mt-2 text-2xl font-semibold">{visiblePayments.length}</div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-4">
-              <div className="text-xs text-muted-foreground">{t('На подтверждении', 'Pending')}</div>
-              <div className="mt-2 text-2xl font-semibold text-amber-700">{pendingCount}</div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-4">
-              <div className="text-xs text-muted-foreground">{t('Подтверждено / сумма', 'Approved / amount')}</div>
-              <div className="mt-2 text-2xl font-semibold text-emerald-700">
-                {approvedCount} / {money(totalApproved, locale)}
+            <CardContent className="flex flex-col items-center justify-center gap-2 px-4 py-10 text-center">
+              <div className="rounded-full bg-stone-100 p-3 text-stone-500">
+                <Wallet className="h-5 w-5" />
+              </div>
+              <div className="text-sm font-semibold text-stone-900">
+                {t('В журнале пока нет выплат', 'The payment journal is empty')}
+              </div>
+              <div className="max-w-md text-sm text-muted-foreground">
+                {isOwner
+                  ? t('Зафиксируй первую выплату или измени фильтр сотрудника.', 'Record the first payment or change the employee filter.')
+                  : t('Когда появятся выплаты, они будут собраны здесь по месяцам.', 'When payments appear, they will be grouped here by month.')}
               </div>
             </CardContent>
           </Card>
-        </section>
-
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between gap-4 space-y-0">
-            <CardTitle>{isOwner ? t('Все выплаты', 'All payments') : t('История моих выплат', 'My payment history')}</CardTitle>
-            {isOwner ? (
-              <select
-                className="h-10 rounded-md border bg-input-background px-3 text-sm"
-                value={selectedEmployeeId}
-                onChange={(event) => setSelectedEmployeeId(event.target.value)}
-              >
-                <option value="all">{t('Все сотрудники', 'All employees')}</option>
-                {visibleEmployees.map((employee) => (
-                  <option key={employee.id} value={employee.id}>
-                    {employee.name}
-                  </option>
-                ))}
-              </select>
-            ) : null}
-          </CardHeader>
-          <CardContent className="overflow-auto">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t('Дата', 'Date')}</TableHead>
-                  <TableHead>{t('Сотрудник', 'Employee')}</TableHead>
-                  <TableHead>{t('Сумма', 'Amount')}</TableHead>
-                  <TableHead>{t('Комментарий', 'Comment')}</TableHead>
-                  <TableHead>{t('Статус', 'Status')}</TableHead>
-                  <TableHead className="w-[320px]">{t('Действия', 'Actions')}</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {visiblePayments.map((payment) => {
-                  const employee = employees.find((item) => item.id === payment.employeeId);
-                  const canEdit = isOwner || payment.status === 'pending';
-                  const canDelete = isOwner ? payment.status !== 'approved' : payment.status === 'pending';
-                  const canConfirm = isOwner && payment.status === 'pending';
-                  const canReject = isOwner && payment.status === 'pending';
-
-                  return (
-                    <TableRow key={payment.id}>
-                      <TableCell>{payment.date}</TableCell>
-                      <TableCell>{employee?.name ?? t('Сотрудник', 'Employee')}</TableCell>
-                      <TableCell>{money(payment.amount, locale)}</TableCell>
-                      <TableCell>{payment.comment || '-'}</TableCell>
-                      <TableCell>
-                        <PaymentStatusBadge status={payment.status} />
-                      </TableCell>
-                      <TableCell className="space-x-2">
-                        {canConfirm ? (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => void handleConfirmPayment(payment.id)}
-                          >
-                            <CheckCircle2 className="h-4 w-4" />
-                            {t('Подтвердить', 'Approve')}
-                          </Button>
-                        ) : null}
-                        {canReject ? (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => void handleRejectPayment(payment.id)}
-                          >
-                            <XCircle className="h-4 w-4" />
-                            {t('Отклонить', 'Reject')}
-                          </Button>
-                        ) : null}
-                        {canEdit ? (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setEditingPayment({
-                              paymentId: payment.id,
-                              amount: payment.amount,
-                              date: payment.date,
-                              comment: payment.comment,
-                            })}
-                          >
-                            <Pencil className="h-4 w-4" />
-                            {t('Изменить', 'Edit')}
-                          </Button>
-                        ) : null}
-                        {canDelete ? (
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => void handleDeletePayment(payment.id)}
-                          >
-                            <Trash2 className="h-4 w-4" />
-                            {t('Удалить', 'Delete')}
-                          </Button>
-                        ) : null}
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-
-                {visiblePayments.length === 0 ? (
-                  <TableRow>
-                    <TableCell colSpan={6} className="py-8 text-center text-sm text-muted-foreground">
-                      {isOwner
-                        ? t('Пока нет ни одной выплаты за выбранный период.', 'There are no payments for the selected period yet.')
-                        : t('У тебя пока нет ни одной выплаты.', 'You do not have any payments yet.')}
-                    </TableCell>
-                  </TableRow>
-                ) : null}
-              </TableBody>
-            </Table>
-          </CardContent>
-        </Card>
+        )}
       </main>
 
-      <AddPaymentModal
-        open={modalOpen}
-        employees={visibleEmployees}
-        fixedEmployeeId={isOwner ? null : myEmployeeId}
-        onClose={() => setModalOpen(false)}
-        onSubmit={handleAddPayment}
-      />
+      {isOwner ? (
+        <AddPaymentModal
+          open={modalOpen}
+          employees={visibleEmployees}
+          fixedEmployeeId={null}
+          onClose={() => setModalOpen(false)}
+          onSubmit={handleAddPayment}
+        />
+      ) : null}
 
       <EditPaymentModal
         open={editingPayment !== null}

--- a/app/pages/Payments.tsx
+++ b/app/pages/Payments.tsx
@@ -1,9 +1,10 @@
-import { Pencil, Trash2, Wallet } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { ChevronDown, Pencil, Trash2, Wallet } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
 import { toast } from 'sonner';
 import { AddPaymentModal } from '../components/AddPaymentModal';
 import { EditPaymentModal } from '../components/EditPaymentModal';
 import { PaymentStatusBadge } from '../components/PaymentStatusBadge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../components/ui/collapsible';
 import { Button } from '../components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import {
@@ -14,6 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from '../components/ui/table';
+import { cn } from '../components/ui/utils';
 import { useApp } from '../context/AppContext';
 import { useLanguage } from '../context/LanguageContext';
 import type { Payment } from '../domain/types';
@@ -116,6 +118,8 @@ export default function PaymentsPage() {
   const [selectedEmployeeId, setSelectedEmployeeId] = useState('all');
   const [modalOpen, setModalOpen] = useState(false);
   const [editingPayment, setEditingPayment] = useState<EditPaymentState | null>(null);
+  const [openMonthKeys, setOpenMonthKeys] = useState<string[]>([]);
+  const [hasInitializedMonthState, setHasInitializedMonthState] = useState(false);
 
   const visibleEmployees = useMemo(() => {
     const active = employees.filter((employee) => !employee.archived);
@@ -148,6 +152,35 @@ export default function PaymentsPage() {
   ), [visiblePayments]);
 
   const latestMonth = paymentGroups[0] ?? null;
+
+  useEffect(() => {
+    const validMonthKeys = paymentGroups.map((group) => group.key);
+
+    setOpenMonthKeys((prev) => prev.filter((key) => validMonthKeys.includes(key)));
+
+    if (!hasInitializedMonthState && validMonthKeys.length > 0) {
+      setOpenMonthKeys([validMonthKeys[0]]);
+      setHasInitializedMonthState(true);
+    }
+  }, [hasInitializedMonthState, paymentGroups]);
+
+  const toggleMonth = (monthKey: string, isOpen: boolean) => {
+    setOpenMonthKeys((prev) => {
+      if (isOpen) {
+        return prev.includes(monthKey) ? prev : [...prev, monthKey];
+      }
+
+      return prev.filter((key) => key !== monthKey);
+    });
+  };
+
+  const expandAllMonths = () => {
+    setOpenMonthKeys(paymentGroups.map((group) => group.key));
+  };
+
+  const collapseAllMonths = () => {
+    setOpenMonthKeys([]);
+  };
 
   const handleAddPayment = async (input: Parameters<typeof addPayment>[0]) => {
     const result = await addPayment(input);
@@ -267,118 +300,171 @@ export default function PaymentsPage() {
 
         {paymentGroups.length > 0 ? (
           <section className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div className="text-xs text-muted-foreground">
+                {t(
+                  'Нажми на месяц, чтобы свернуть или раскрыть его записи.',
+                  'Click a month to collapse or expand its entries.',
+                )}
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8"
+                  onClick={collapseAllMonths}
+                  data-testid="collapse-all-months"
+                >
+                  {t('Свернуть все', 'Collapse all')}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="h-8"
+                  onClick={expandAllMonths}
+                  data-testid="expand-all-months"
+                >
+                  {t('Развернуть все', 'Expand all')}
+                </Button>
+              </div>
+            </div>
             {paymentGroups.map((group) => (
-              <Card
+              <Collapsible
                 key={group.key}
-                className="gap-0 overflow-hidden"
+                open={openMonthKeys.includes(group.key)}
+                onOpenChange={(isOpen) => toggleMonth(group.key, isOpen)}
                 data-testid="payment-month-group"
                 data-month-key={group.key}
               >
-                <CardHeader className="flex flex-col gap-2 border-b px-4 py-3 sm:flex-row sm:items-center sm:justify-between sm:px-5">
-                  <div>
-                    <CardTitle className="text-base font-semibold text-stone-950">
-                      {group.label}
-                    </CardTitle>
-                    <div className="mt-1 text-xs text-muted-foreground">
-                      {t('Записей', 'Records')}: {group.payments.length}
-                      {' · '}
-                      {t('Учтено в расчете', 'Counted in payroll')}: {money(group.approvedTotal, locale)}
-                    </div>
-                  </div>
-                  {group.legacyCount > 0 ? (
-                    <div className="rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800">
-                      {t('Особые записи', 'Special records')}: {group.legacyCount}
-                    </div>
-                  ) : null}
-                </CardHeader>
-
-                <CardContent className="overflow-x-auto p-0">
-                  <Table className="min-w-[760px] table-fixed">
-                    <TableHeader>
-                      <TableRow className="bg-stone-50/70">
-                        <TableHead className="w-[112px] px-4 py-2 text-xs">{t('Дата', 'Date')}</TableHead>
-                        <TableHead className="w-[220px] px-4 py-2 text-xs">{t('Сотрудник', 'Employee')}</TableHead>
-                        <TableHead className="w-[140px] px-4 py-2 text-xs">{t('Сумма', 'Amount')}</TableHead>
-                        <TableHead className="px-4 py-2 text-xs">{t('Комментарий', 'Comment')}</TableHead>
-                        {isOwner ? (
-                          <TableHead className="w-[132px] px-4 py-2 text-right text-xs">
-                            {t('Действия', 'Actions')}
-                          </TableHead>
+                <Card className="gap-0 overflow-hidden">
+                  <CollapsibleTrigger
+                    className="w-full text-left"
+                    data-testid={`payment-month-toggle-${group.key}`}
+                  >
+                    <CardHeader className={cn(
+                      'flex flex-col gap-2 px-4 py-3 transition-colors hover:bg-stone-50 sm:flex-row sm:items-center sm:justify-between sm:px-5',
+                      openMonthKeys.includes(group.key) ? 'border-b' : '',
+                    )}>
+                      <div className="flex items-start gap-3">
+                        <ChevronDown
+                          className={cn(
+                            'mt-0.5 h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200',
+                            openMonthKeys.includes(group.key) ? 'rotate-0' : '-rotate-90',
+                          )}
+                        />
+                        <div>
+                          <CardTitle className="text-base font-semibold text-stone-950">
+                            {group.label}
+                          </CardTitle>
+                          <div className="mt-1 text-xs text-muted-foreground">
+                            {t('Записей', 'Records')}: {group.payments.length}
+                            {' · '}
+                            {t('Учтено в расчете', 'Counted in payroll')}: {money(group.approvedTotal, locale)}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        {group.legacyCount > 0 ? (
+                          <div className="rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800">
+                            {t('Особые записи', 'Special records')}: {group.legacyCount}
+                          </div>
                         ) : null}
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {group.payments.map((payment) => {
-                        const employee = employeeById.get(payment.employeeId);
-                        const canEdit = isOwner;
-                        const canDelete = isOwner && payment.status !== 'approved';
-                        const comment = payment.comment.trim() || t('Без комментария', 'No comment');
+                      </div>
+                    </CardHeader>
+                  </CollapsibleTrigger>
 
-                        return (
-                          <TableRow key={payment.id} data-testid="payment-row">
-                            <TableCell className="px-4 py-2 text-sm font-medium text-stone-800">
-                              {payment.date}
-                            </TableCell>
-                            <TableCell className="px-4 py-2 text-sm">
-                              <div className="font-medium text-stone-900">
-                                {employee?.name ?? t('Сотрудник', 'Employee')}
-                              </div>
-                            </TableCell>
-                            <TableCell className="px-4 py-2 text-sm font-semibold text-stone-950">
-                              {money(payment.amount, locale)}
-                            </TableCell>
-                            <TableCell className="px-4 py-2 text-sm">
-                              <div className="flex min-w-0 max-w-[360px] items-center gap-2">
-                                <span className="truncate text-stone-700" title={comment}>
-                                  {comment}
-                                </span>
-                                {payment.status !== 'approved' ? (
-                                  <span data-testid="payment-legacy-status">
-                                    <PaymentStatusBadge status={payment.status} />
-                                  </span>
-                                ) : null}
-                              </div>
-                            </TableCell>
+                  <CollapsibleContent data-testid={`payment-month-content-${group.key}`}>
+                    <CardContent className="overflow-x-auto p-0">
+                      <Table className="min-w-[760px] table-fixed">
+                        <TableHeader>
+                          <TableRow className="bg-stone-50/70">
+                            <TableHead className="w-[112px] px-4 py-2 text-xs">{t('Дата', 'Date')}</TableHead>
+                            <TableHead className="w-[220px] px-4 py-2 text-xs">{t('Сотрудник', 'Employee')}</TableHead>
+                            <TableHead className="w-[140px] px-4 py-2 text-xs">{t('Сумма', 'Amount')}</TableHead>
+                            <TableHead className="px-4 py-2 text-xs">{t('Комментарий', 'Comment')}</TableHead>
                             {isOwner ? (
-                              <TableCell className="px-4 py-2 text-right" data-testid="payment-actions">
-                                <div className="flex justify-end gap-1">
-                                  {canEdit ? (
-                                    <Button
-                                      variant="outline"
-                                      size="sm"
-                                      className="h-8 px-2"
-                                      onClick={() => setEditingPayment({
-                                        paymentId: payment.id,
-                                        amount: payment.amount,
-                                        date: payment.date,
-                                        comment: payment.comment,
-                                      })}
-                                    >
-                                      <Pencil className="h-3.5 w-3.5" />
-                                      <span className="sr-only sm:not-sr-only sm:ml-1">{t('Изменить', 'Edit')}</span>
-                                    </Button>
-                                  ) : null}
-                                  {canDelete ? (
-                                    <Button
-                                      variant="outline"
-                                      size="sm"
-                                      className="h-8 px-2 text-rose-700 hover:text-rose-800"
-                                      onClick={() => void handleDeletePayment(payment.id)}
-                                    >
-                                      <Trash2 className="h-3.5 w-3.5" />
-                                      <span className="sr-only sm:not-sr-only sm:ml-1">{t('Удалить', 'Delete')}</span>
-                                    </Button>
-                                  ) : null}
-                                </div>
-                              </TableCell>
+                              <TableHead className="w-[132px] px-4 py-2 text-right text-xs">
+                                {t('Действия', 'Actions')}
+                              </TableHead>
                             ) : null}
                           </TableRow>
-                        );
-                      })}
-                    </TableBody>
-                  </Table>
-                </CardContent>
-              </Card>
+                        </TableHeader>
+                        <TableBody>
+                          {group.payments.map((payment) => {
+                            const employee = employeeById.get(payment.employeeId);
+                            const canEdit = isOwner;
+                            const canDelete = isOwner && payment.status !== 'approved';
+                            const comment = payment.comment.trim() || t('Без комментария', 'No comment');
+
+                            return (
+                              <TableRow key={payment.id} data-testid="payment-row">
+                                <TableCell className="px-4 py-2 text-sm font-medium text-stone-800">
+                                  {payment.date}
+                                </TableCell>
+                                <TableCell className="px-4 py-2 text-sm">
+                                  <div className="font-medium text-stone-900">
+                                    {employee?.name ?? t('Сотрудник', 'Employee')}
+                                  </div>
+                                </TableCell>
+                                <TableCell className="px-4 py-2 text-sm font-semibold text-stone-950">
+                                  {money(payment.amount, locale)}
+                                </TableCell>
+                                <TableCell className="px-4 py-2 text-sm">
+                                  <div className="flex min-w-0 max-w-[360px] items-center gap-2">
+                                    <span className="truncate text-stone-700" title={comment}>
+                                      {comment}
+                                    </span>
+                                    {payment.status !== 'approved' ? (
+                                      <span data-testid="payment-legacy-status">
+                                        <PaymentStatusBadge status={payment.status} />
+                                      </span>
+                                    ) : null}
+                                  </div>
+                                </TableCell>
+                                {isOwner ? (
+                                  <TableCell className="px-4 py-2 text-right" data-testid="payment-actions">
+                                    <div className="flex justify-end gap-1">
+                                      {canEdit ? (
+                                        <Button
+                                          variant="outline"
+                                          size="sm"
+                                          className="h-8 px-2"
+                                          onClick={() => setEditingPayment({
+                                            paymentId: payment.id,
+                                            amount: payment.amount,
+                                            date: payment.date,
+                                            comment: payment.comment,
+                                          })}
+                                        >
+                                          <Pencil className="h-3.5 w-3.5" />
+                                          <span className="sr-only sm:not-sr-only sm:ml-1">{t('Изменить', 'Edit')}</span>
+                                        </Button>
+                                      ) : null}
+                                      {canDelete ? (
+                                        <Button
+                                          variant="outline"
+                                          size="sm"
+                                          className="h-8 px-2 text-rose-700 hover:text-rose-800"
+                                          onClick={() => void handleDeletePayment(payment.id)}
+                                        >
+                                          <Trash2 className="h-3.5 w-3.5" />
+                                          <span className="sr-only sm:not-sr-only sm:ml-1">{t('Удалить', 'Delete')}</span>
+                                        </Button>
+                                      ) : null}
+                                    </div>
+                                  </TableCell>
+                                ) : null}
+                              </TableRow>
+                            );
+                          })}
+                        </TableBody>
+                      </Table>
+                    </CardContent>
+                  </CollapsibleContent>
+                </Card>
+              </Collapsible>
             ))}
           </section>
         ) : (

--- a/e2e/payments-journal.spec.ts
+++ b/e2e/payments-journal.spec.ts
@@ -387,12 +387,22 @@ test.describe('payments journal', () => {
     await expect(groups.nth(0)).toContainText('April 2026');
     await expect(groups.nth(1)).toContainText('March 2026');
 
+    await expect(page.getByTestId('payment-month-content-2026-04')).toBeVisible();
+    await expect(page.getByTestId('payment-month-content-2026-03')).not.toBeVisible();
     await expect(page.getByText('April salary payout with a deliberately long note')).toBeVisible();
-    await expect(page.getByText('Legacy pending cash note')).toBeVisible();
-    await expect(page.getByText('Rejected correction kept for history')).toBeVisible();
-    await expect(page.getByTestId('payment-legacy-status')).toHaveCount(2);
+    await expect(page.getByText('Rejected correction kept for history')).toHaveCount(0);
+    await expect(page.getByTestId('payment-legacy-status')).toHaveCount(1);
     await expect(page.getByRole('columnheader', { name: 'Status' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: /Approve|Reject/ })).toHaveCount(0);
+
+    await page.getByTestId('collapse-all-months').click();
+    await expect(page.getByTestId('payment-month-content-2026-04')).not.toBeVisible();
+    await expect(page.getByText('April salary payout with a deliberately long note')).toHaveCount(0);
+
+    await page.getByTestId('expand-all-months').click();
+    await expect(page.getByTestId('payment-month-content-2026-03')).toBeVisible();
+    await expect(page.getByText('Legacy pending cash note')).toBeVisible();
+    await expect(page.getByText('Rejected correction kept for history')).toBeVisible();
 
     const firstActionsBox = await page.getByTestId('payment-actions').first().boundingBox();
     expect(firstActionsBox?.width ?? 999).toBeLessThan(180);
@@ -417,6 +427,9 @@ test.describe('payments journal', () => {
       comment: 'One-cell journal payment',
       status: 'approved',
     }]);
+    await expect(page.getByTestId('payment-row')).toHaveCount(3);
+
+    await page.getByTestId('expand-all-months').click();
     await expect(page.getByTestId('payment-row')).toHaveCount(5);
   });
 
@@ -426,6 +439,7 @@ test.describe('payments journal', () => {
 
     await expect(page.getByTestId('payments-journal')).toBeVisible();
     await expect(page.getByText('April salary payout with a deliberately long note')).toBeVisible();
+    await page.getByTestId('expand-all-months').click();
     await expect(page.getByText('Rejected correction kept for history')).toBeVisible();
     await expect(page.getByText('Legacy pending cash note')).toHaveCount(0);
     await expect(page.getByTestId('add-payment-button')).toHaveCount(0);

--- a/e2e/payments-journal.spec.ts
+++ b/e2e/payments-journal.spec.ts
@@ -1,0 +1,448 @@
+import { expect, test, type Page, type Route } from '@playwright/test';
+
+const SUPABASE_URL = 'https://nqwxeuewkimonifeckdr.supabase.co';
+const SUPABASE_STORAGE_KEY = 'sb-nqwxeuewkimonifeckdr-auth-token';
+const LANGUAGE_STORAGE_KEY = 'pvz-schedule.language';
+const PREFERENCES_STORAGE_KEY = 'pvz-schedule-ui-v1';
+
+type FixtureRole = 'admin' | 'employee';
+type PaymentStatusFixture = 'pending' | 'approved' | 'rejected';
+
+interface FixtureData {
+  session: Record<string, unknown>;
+  profile: Record<string, unknown>;
+  organization: Record<string, unknown>;
+  employees: Record<string, unknown>[];
+  shifts: Record<string, unknown>[];
+  payments: Record<string, unknown>[];
+  rateHistory: Record<string, unknown>[];
+  scheduleMonths: Record<string, unknown>[];
+}
+
+interface RpcCalls {
+  creates: Array<{
+    employeeId: string;
+    amount: number;
+    date: string;
+    comment: string;
+    status: PaymentStatusFixture;
+  }>;
+  updates: Array<{ paymentId: string }>;
+  deletes: string[];
+}
+
+const jsonHeaders = {
+  'access-control-allow-origin': '*',
+  'access-control-allow-methods': 'GET,POST,OPTIONS',
+  'access-control-allow-headers': '*',
+  'content-type': 'application/json',
+};
+
+const encodeBase64Url = (value: string): string => (
+  Buffer.from(value, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '')
+);
+
+const createFakeJwt = (subject: string, exp: number): string => {
+  const header = encodeBase64Url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = encodeBase64Url(JSON.stringify({ sub: subject, exp, role: 'authenticated' }));
+  return `${header}.${payload}.signature`;
+};
+
+const createPaymentRow = (
+  id: string,
+  employeeId: string,
+  amount: number,
+  paymentDate: string,
+  comment: string,
+  status: PaymentStatusFixture,
+  createdAt: string,
+) => ({
+  id,
+  user_id: 'user-admin',
+  organization_id: 'org-1',
+  employee_id: employeeId,
+  amount,
+  payment_date: paymentDate,
+  comment,
+  status,
+  requested_by_auth_user_id: 'user-admin',
+  created_by_auth_user_id: 'user-admin',
+  approved_by_auth_user_id: status === 'approved' ? 'user-admin' : null,
+  confirmed_by_auth_user_id: null,
+  requested_by_profile_id: 'user-admin',
+  created_by_profile_id: 'user-admin',
+  approved_by_profile_id: status === 'approved' ? 'user-admin' : null,
+  confirmed_by_profile_id: null,
+  approved_at: status === 'approved' ? createdAt : null,
+  edited_by_admin: false,
+  created_at: createdAt,
+  updated_at: createdAt,
+});
+
+const buildFixtureData = (role: FixtureRole): FixtureData => {
+  const authUserId = role === 'admin' ? 'user-admin' : 'user-employee';
+  const expiresAt = Math.floor(Date.now() / 1000) + 60 * 60;
+  const accessToken = createFakeJwt(authUserId, expiresAt);
+  const baseNow = '2026-04-23T08:00:00.000Z';
+
+  const employees = [
+    {
+      id: 'emp-owner',
+      user_id: 'user-admin',
+      organization_id: 'org-1',
+      profile_id: 'user-admin',
+      auth_user_id: 'user-admin',
+      work_email: 'nik@example.com',
+      status: 'active',
+      created_by_profile_id: 'user-admin',
+      is_owner: true,
+      hired_at: '2026-01-01',
+      terminated_at: null,
+      name: 'Nikita Owner',
+      daily_rate: 5000,
+      archived: false,
+      archived_at: null,
+      created_at: '2026-01-01T08:00:00.000Z',
+      updated_at: baseNow,
+    },
+    {
+      id: 'emp-pavel',
+      user_id: 'user-admin',
+      organization_id: 'org-1',
+      profile_id: 'user-employee',
+      auth_user_id: 'user-employee',
+      work_email: 'pavel@example.com',
+      status: 'active',
+      created_by_profile_id: 'user-admin',
+      is_owner: false,
+      hired_at: '2026-01-02',
+      terminated_at: null,
+      name: 'Pavel Smirnov',
+      daily_rate: 4300,
+      archived: false,
+      archived_at: null,
+      created_at: '2026-01-02T08:00:00.000Z',
+      updated_at: baseNow,
+    },
+    {
+      id: 'emp-alina',
+      user_id: 'user-admin',
+      organization_id: 'org-1',
+      profile_id: null,
+      auth_user_id: null,
+      work_email: 'alina@example.com',
+      status: 'active',
+      created_by_profile_id: 'user-admin',
+      is_owner: false,
+      hired_at: '2026-01-05',
+      terminated_at: null,
+      name: 'Alina Vorobeva',
+      daily_rate: 4100,
+      archived: false,
+      archived_at: null,
+      created_at: '2026-01-05T08:00:00.000Z',
+      updated_at: baseNow,
+    },
+  ];
+
+  return {
+    session: {
+      access_token: accessToken,
+      refresh_token: 'test-refresh-token',
+      token_type: 'bearer',
+      expires_in: 60 * 60,
+      expires_at: expiresAt,
+      user: {
+        id: authUserId,
+        aud: 'authenticated',
+        role: 'authenticated',
+        email: role === 'admin' ? 'nik@example.com' : 'pavel@example.com',
+        email_confirmed_at: '2026-04-01T00:00:00.000Z',
+        phone: '',
+        confirmed_at: '2026-04-01T00:00:00.000Z',
+        last_sign_in_at: baseNow,
+        app_metadata: {
+          provider: 'email',
+          providers: ['email'],
+        },
+        user_metadata: {
+          name: role === 'admin' ? 'Nikita Owner' : 'Pavel Smirnov',
+          sub: `sub-${authUserId}`,
+        },
+        identities: [],
+        created_at: '2026-04-01T00:00:00.000Z',
+        updated_at: baseNow,
+      },
+    },
+    profile: {
+      id: authUserId,
+      organization_id: 'org-1',
+      role,
+      display_name: role === 'admin' ? 'Nikita Owner' : 'Pavel Smirnov',
+      is_active: true,
+      created_at: '2026-04-01T00:00:00.000Z',
+      updated_at: baseNow,
+    },
+    organization: {
+      id: 'org-1',
+      created_by: 'user-admin',
+      name: 'PVZ',
+      created_at: '2026-04-01T00:00:00.000Z',
+      updated_at: baseNow,
+    },
+    employees,
+    shifts: [],
+    payments: [
+      createPaymentRow(
+        'payment-apr-approved',
+        'emp-pavel',
+        4300,
+        '2026-04-21',
+        'April salary payout with a deliberately long note that should stay compact',
+        'approved',
+        '2026-04-21T09:00:00.000Z',
+      ),
+      createPaymentRow(
+        'payment-apr-pending',
+        'emp-alina',
+        1000,
+        '2026-04-20',
+        'Legacy pending cash note',
+        'pending',
+        '2026-04-20T09:00:00.000Z',
+      ),
+      createPaymentRow(
+        'payment-mar-rejected',
+        'emp-pavel',
+        500,
+        '2026-03-15',
+        'Rejected correction kept for history',
+        'rejected',
+        '2026-03-15T09:00:00.000Z',
+      ),
+      createPaymentRow(
+        'payment-mar-approved',
+        'emp-owner',
+        5000,
+        '2026-03-01',
+        'Owner March payout',
+        'approved',
+        '2026-03-01T09:00:00.000Z',
+      ),
+    ],
+    rateHistory: employees.map((employee) => ({
+      id: `rate-${employee.id}`,
+      employee_id: employee.id,
+      organization_id: 'org-1',
+      rate: employee.daily_rate,
+      valid_from: employee.hired_at,
+      valid_to: null,
+      created_by_profile_id: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+    })),
+    scheduleMonths: [],
+  };
+};
+
+const fulfillJson = async (route: Route, body: unknown) => {
+  await route.fulfill({
+    status: 200,
+    headers: jsonHeaders,
+    body: JSON.stringify(body),
+  });
+};
+
+const mockSupabase = async (page: Page, fixture: FixtureData, rpcCalls: RpcCalls) => {
+  await page.route(`${SUPABASE_URL}/rest/v1/**`, async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (request.method() === 'OPTIONS') {
+      await route.fulfill({ status: 204, headers: jsonHeaders, body: '' });
+      return;
+    }
+
+    switch (url.pathname) {
+      case '/rest/v1/rpc/ensure_profile_membership':
+        await fulfillJson(route, null);
+        return;
+      case '/rest/v1/rpc/create_payment_record': {
+        const payload = request.postDataJSON() as {
+          employee_id_input: string;
+          amount_input: number;
+          payment_date_input: string;
+          comment_input: string;
+        };
+        const now = new Date().toISOString();
+        const nextPayment = createPaymentRow(
+          `payment-new-${rpcCalls.creates.length + 1}`,
+          payload.employee_id_input,
+          payload.amount_input,
+          payload.payment_date_input,
+          payload.comment_input,
+          'approved',
+          now,
+        );
+
+        fixture.payments.unshift(nextPayment);
+        rpcCalls.creates.push({
+          employeeId: payload.employee_id_input,
+          amount: payload.amount_input,
+          date: payload.payment_date_input,
+          comment: payload.comment_input,
+          status: 'approved',
+        });
+        await fulfillJson(route, nextPayment);
+        return;
+      }
+      case '/rest/v1/rpc/update_payment_record': {
+        const payload = request.postDataJSON() as { payment_id_input: string };
+        rpcCalls.updates.push({ paymentId: payload.payment_id_input });
+        const payment = fixture.payments.find((item) => item.id === payload.payment_id_input);
+        await fulfillJson(route, payment ?? null);
+        return;
+      }
+      case '/rest/v1/rpc/delete_payment_record': {
+        const payload = request.postDataJSON() as { payment_id_input: string };
+        fixture.payments = fixture.payments.filter((item) => item.id !== payload.payment_id_input);
+        rpcCalls.deletes.push(payload.payment_id_input);
+        await fulfillJson(route, null);
+        return;
+      }
+      case '/rest/v1/profiles':
+        await fulfillJson(route, fixture.profile);
+        return;
+      case '/rest/v1/organizations':
+        await fulfillJson(route, fixture.organization);
+        return;
+      case '/rest/v1/employees':
+        await fulfillJson(route, fixture.employees);
+        return;
+      case '/rest/v1/shifts':
+        await fulfillJson(route, fixture.shifts);
+        return;
+      case '/rest/v1/payments':
+        await fulfillJson(route, fixture.payments);
+        return;
+      case '/rest/v1/employee_rate_history':
+        await fulfillJson(route, fixture.rateHistory);
+        return;
+      case '/rest/v1/schedule_months':
+        await fulfillJson(route, fixture.scheduleMonths);
+        return;
+      default:
+        throw new Error(`Unhandled Supabase request: ${request.method()} ${url.pathname}${url.search}`);
+    }
+  });
+};
+
+const bootstrapPayments = async (page: Page, role: FixtureRole) => {
+  const fixture = buildFixtureData(role);
+  const rpcCalls: RpcCalls = { creates: [], updates: [], deletes: [] };
+
+  await mockSupabase(page, fixture, rpcCalls);
+  await page.addInitScript(
+    ({ session, storageKey, languageStorageKey, preferencesStorageKey }) => {
+      window.localStorage.clear();
+      window.sessionStorage.clear();
+      window.localStorage.setItem(storageKey, JSON.stringify(session));
+      window.localStorage.setItem(languageStorageKey, 'en');
+      window.localStorage.setItem(preferencesStorageKey, JSON.stringify({
+        selectedMonth: 4,
+        selectedYear: 2026,
+      }));
+    },
+    {
+      session: fixture.session,
+      storageKey: SUPABASE_STORAGE_KEY,
+      languageStorageKey: LANGUAGE_STORAGE_KEY,
+      preferencesStorageKey: PREFERENCES_STORAGE_KEY,
+    },
+  );
+
+  return { fixture, rpcCalls };
+};
+
+test.describe('payments journal', () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  test('admin sees existing payments grouped by month without approval controls', async ({ page }) => {
+    await bootstrapPayments(page, 'admin');
+    await page.goto('/admin/payments');
+
+    await expect(page.getByTestId('payments-journal')).toBeVisible();
+    await expect(page.getByTestId('payments-summary')).toBeVisible();
+
+    const summaryBox = await page.getByTestId('payments-summary').boundingBox();
+    expect(summaryBox?.height ?? 0).toBeLessThan(240);
+
+    const groups = page.getByTestId('payment-month-group');
+    await expect(groups).toHaveCount(2);
+    await expect(groups.nth(0)).toHaveAttribute('data-month-key', '2026-04');
+    await expect(groups.nth(1)).toHaveAttribute('data-month-key', '2026-03');
+    await expect(groups.nth(0)).toContainText('April 2026');
+    await expect(groups.nth(1)).toContainText('March 2026');
+
+    await expect(page.getByText('April salary payout with a deliberately long note')).toBeVisible();
+    await expect(page.getByText('Legacy pending cash note')).toBeVisible();
+    await expect(page.getByText('Rejected correction kept for history')).toBeVisible();
+    await expect(page.getByTestId('payment-legacy-status')).toHaveCount(2);
+    await expect(page.getByRole('columnheader', { name: 'Status' })).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /Approve|Reject/ })).toHaveCount(0);
+
+    const firstActionsBox = await page.getByTestId('payment-actions').first().boundingBox();
+    expect(firstActionsBox?.width ?? 999).toBeLessThan(180);
+  });
+
+  test('admin-created payment is recorded as approved for payroll compatibility', async ({ page }) => {
+    const { rpcCalls } = await bootstrapPayments(page, 'admin');
+    await page.goto('/admin/payments');
+
+    await page.getByTestId('add-payment-button').click();
+    await page.locator('#payment-employee').selectOption('emp-pavel');
+    await page.locator('#payment-amount').fill('1234');
+    await page.locator('#payment-date').fill('2026-04-23');
+    await page.locator('#payment-comment').fill('One-cell journal payment');
+    await page.locator('[role="dialog"]').getByRole('button', { name: 'Record payment' }).click();
+
+    await expect(page.getByText('One-cell journal payment')).toBeVisible();
+    expect(rpcCalls.creates).toEqual([{
+      employeeId: 'emp-pavel',
+      amount: 1234,
+      date: '2026-04-23',
+      comment: 'One-cell journal payment',
+      status: 'approved',
+    }]);
+    await expect(page.getByTestId('payment-row')).toHaveCount(5);
+  });
+
+  test('employee sees only own payment history as read-only journal', async ({ page }) => {
+    await bootstrapPayments(page, 'employee');
+    await page.goto('/employee/payments');
+
+    await expect(page.getByTestId('payments-journal')).toBeVisible();
+    await expect(page.getByText('April salary payout with a deliberately long note')).toBeVisible();
+    await expect(page.getByText('Rejected correction kept for history')).toBeVisible();
+    await expect(page.getByText('Legacy pending cash note')).toHaveCount(0);
+    await expect(page.getByTestId('add-payment-button')).toHaveCount(0);
+    await expect(page.getByTestId('payment-actions')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: /Edit|Delete|Approve|Reject/ })).toHaveCount(0);
+  });
+
+  test('mobile journal keeps the monthly structure readable', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await bootstrapPayments(page, 'admin');
+    await page.goto('/admin/payments');
+
+    await expect(page.getByTestId('payments-journal')).toBeVisible();
+    await expect(page.getByTestId('payment-month-group').first()).toContainText('April 2026');
+    await expect(page.getByText('April salary payout with a deliberately long note')).toBeVisible();
+
+    const summaryBox = await page.getByTestId('payments-summary').boundingBox();
+    expect(summaryBox?.height ?? 999).toBeLessThan(360);
+  });
+});


### PR DESCRIPTION
## Summary
- Reworked the payments page into a compact monthly journal grouped by `payment.date`.
- Removed approve/reject actions, pending metrics, and the status column from the main UX.
- Kept legacy `pending` / `rejected` records visible as small secondary badges next to comments.
- Made the admin flow add/edit focused, while employee payments are read-only history.

## Data compatibility
- No database schema, migration, domain type, or RPC changes.
- Existing payment records and statuses are preserved and remain readable.
- New admin-created payments still use the existing `create_payment_record` RPC, which stores them as `approved`, so `paidApproved` payroll calculations continue to work.
- Approved payments are not shown with a delete action because the existing backend intentionally blocks deleting approved records.

## Verification
- `npm.cmd run typecheck`
- `npm.cmd run lint`
- `npm.cmd run test`
- `npm.cmd run build`
- `npm.cmd run test:e2e`

## Deployments
- Preview: https://pvz-schedule-9bbv37zot-nick-rimers-projects.vercel.app
- Production: https://pvz-schedule.vercel.app